### PR TITLE
Update README.md, quitar portabilidad como prioridad

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Soñamos construir una infraestructura de herramientas, documentación, técnica
 2. Organizar tu proyecto (dónde va qué cosa)
 3. Tener un proceso de desarrollo (cómo configurar tus compilaciones, pruebas y desplegue)
 4. Reusar periféricos y técnicas implementados en industria (mejoras tu CV y no reinventas la rueda)
-5. Tener cierta Independencia de fabricante (Puedas cambiar de fabricante sin tantísima modificación)
+5. Tener cierta Independencia de hardware en el código
 
 El cómo vamos a lograr ésto está estipulado en el archivo de [versiones.md](https://github.com/CoDePretzel/CoDePretzel_Framework/blob/main/versiones.md) donde se explica:
 
@@ -20,9 +20,9 @@ Algunos ejemplos de aplicación de los principios se pueden consultar [aqui](htt
 
 ## Prioridad de funcionalidades para el Framework de CoDe Pretzel
 
-- Portabilidad (entre dispositivos conocidos y previamente enlistados)
-- Reusabilidad (mantenibilidad)
-- Estandiración
+- Reusabilidad
+- Estandiración de un proceso de desarrollo
+- Mantenibilidad
 
 ## La documentación del framework es parte del mismo! ![](https://readthedocs.org/projects/code-pretzel-framework/badge/?version=latest)
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Algunos ejemplos de aplicación de los principios se pueden consultar [aqui](htt
 ## Prioridad de funcionalidades para el Framework de CoDe Pretzel
 
 - Reusabilidad
-- Estandiración de un proceso de desarrollo
+- Estandarización de un proceso de desarrollo
 - Mantenibilidad
 
 ## La documentación del framework es parte del mismo! ![](https://readthedocs.org/projects/code-pretzel-framework/badge/?version=latest)

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Soñamos construir una infraestructura de herramientas, documentación, técnica
 2. Organizar tu proyecto (dónde va qué cosa)
 3. Tener un proceso de desarrollo (cómo configurar tus compilaciones, pruebas y desplegue)
 4. Reusar periféricos y técnicas implementados en industria (mejoras tu CV y no reinventas la rueda)
-5. Tener cierta Independencia de hardware en el código
+5. Tener cierta independencia de hardware en el código
 
 El cómo vamos a lograr ésto está estipulado en el archivo de [versiones.md](https://github.com/CoDePretzel/CoDePretzel_Framework/blob/main/versiones.md) donde se explica:
 


### PR DESCRIPTION
Eliminar el principio de portabilidad entre fabricantes y cambiarlo por independencia de hardware, asi como eliminarlo de la lista de prioridades y cambiarlo por "mantenibilidad"